### PR TITLE
Add ScreenshotTaskDelegate to handle a moment when screenshot capture is finished

### DIFF
--- a/Example/Screenshots/ViewController.swift
+++ b/Example/Screenshots/ViewController.swift
@@ -24,6 +24,7 @@ class ViewController: NSViewController {
     systemScreenshots.start()
     
     cliScreenshots.delegate = self
+    cliScreenshots.taskDelegate = self
     cliScreenshots.start()
   }
 
@@ -55,5 +56,11 @@ extension ViewController: ScreenshotWatcherDelegate {
     textField.stringValue = "Success rect: \(screenshot.rect!), retries: \(screenshot.retries)"
     let image = NSImage(byReferencing: screenshot.url)
     imageView.image = image
+  }
+}
+
+extension ViewController: ScreenshotTaskDelegate {
+  func screenshotCLITaskCompleted(_ screenshotCLI: ScreenshotCLI) {
+    print("Screenshot task is completed")
   }
 }

--- a/Screenshots/Classes/Screenshot.swift
+++ b/Screenshots/Classes/Screenshot.swift
@@ -30,6 +30,10 @@ public struct Screenshot {
   }
 }
 
+public protocol ScreenshotTaskDelegate {
+  func screenshotCLITaskCompleted(_ screenshotCLI: ScreenshotCLI)
+}
+
 public protocol ScreenshotWatcherDelegate {
   func screenshotWatcher(_ watcher: ScreenshotWatcher, didCapture screenshot: Screenshot)
 }
@@ -139,6 +143,7 @@ public class ScreenshotCLI: ScreenshotWatcher {
   public static var shared = ScreenshotCLI()
   
   public var delegate: ScreenshotWatcherDelegate?
+  public var taskDelegate: ScreenshotTaskDelegate?
   
   public lazy var screenshotDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
   
@@ -185,6 +190,8 @@ public class ScreenshotCLI: ScreenshotWatcher {
       
       task.launch()
       task.waitUntilExit()
+      
+      self.taskDelegate?.screenshotCLITaskCompleted(self)
       
       self.task = nil
       


### PR DESCRIPTION
Add ScreenshotTaskDelegate to handle a moment when screenshot capture is finished.
Screenshot capture can be finished if:
1) a user took a screenshot;
2) a user pressed "Esc" button.
ScreenshotTaskDelegate callback is called in both cases.