### PR TITLE
Use modern run() method for Process to fix possible crashes

### DIFF
--- a/Sources/Screenshots/ScreenshotCLI.swift
+++ b/Sources/Screenshots/ScreenshotCLI.swift
@@ -164,24 +164,29 @@ public final class ScreenshotCLI: Sendable {
     let task = Process()
     task.standardOutput = pipe
     
-    task.launchPath = "/usr/sbin/screencapture"
-    
+    let executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+    task.executableURL = executableURL
     task.arguments = [args, url.path]
     task.qualityOfService = .userInteractive
+       
+     do {
+       try task.run()
+     } catch let error {
+       throw .processLaunchFailed(error.localizedDescription)
+     }
     
-    task.launch()
-    task.waitUntilExit()
-    
-    guard task.terminationStatus == 0 else {
-      throw .terminationStatusNotZero(Int(task.terminationStatus),
-                                                     pipe.fileHandleForReading.availableData)
-    }
-    
-    // if file doesn't exist then treat is as user cancelled
-    // as there is not another way to know about it
-    guard fileManager.fileExists(atPath: url.path) else {
-      throw .userCancelled
-    }
+     task.waitUntilExit()
+     
+     guard task.terminationStatus == 0 else {
+       throw .terminationStatusNotZero(Int(task.terminationStatus),
+                                       pipe.fileHandleForReading.availableData)
+     }
+     
+     // if file doesn't exist then treat is as user cancelled
+     // as there is not another way to know about it
+     guard fileManager.fileExists(atPath: url.path) else {
+       throw .userCancelled
+     }
   }
   
   private func removeScreenshotFile(_ url: URL) {

--- a/Sources/Screenshots/ScreenshotCLI.swift
+++ b/Sources/Screenshots/ScreenshotCLI.swift
@@ -172,7 +172,8 @@ public final class ScreenshotCLI: Sendable {
      do {
        try task.run()
      } catch let error {
-       throw .processLaunchFailed(error.localizedDescription)
+       let nsError = error as NSError
+       throw .processLaunchFailed(nsError)
      }
     
      task.waitUntilExit()

--- a/Sources/Screenshots/ScreenshotError.swift
+++ b/Sources/Screenshots/ScreenshotError.swift
@@ -4,7 +4,7 @@ public enum ScreenshotError: LocalizedError, Sendable {
   case screenshotDirectoryIsInvalid
   case userCancelled
   case terminationStatusNotZero(_ status: Int, _ outputData: Data)
-  case processLaunchFailed(String)
+  case processLaunchFailed(NSError)
   case cantCreateWindowCaptureURL
   case cantCreateNSImageFromURL
   
@@ -20,8 +20,8 @@ public enum ScreenshotError: LocalizedError, Sendable {
       return "Can't create url for window capture"
     case .cantCreateNSImageFromURL:
       return "Can't create image from file"
-    case .processLaunchFailed(let errorMessage):
-      return "Error running capture tool: \" \(errorMessage) \""
+    case .processLaunchFailed(let nsError):
+      return "Error running capture tool. Error message: \(nsError.localizedDescription). Domain: \(nsError.domain). Code: \(nsError.code)"
     }
   }
 }

--- a/Sources/Screenshots/ScreenshotError.swift
+++ b/Sources/Screenshots/ScreenshotError.swift
@@ -4,6 +4,7 @@ public enum ScreenshotError: LocalizedError, Sendable {
   case screenshotDirectoryIsInvalid
   case userCancelled
   case terminationStatusNotZero(_ status: Int, _ outputData: Data)
+  case processLaunchFailed(String)
   case cantCreateWindowCaptureURL
   case cantCreateNSImageFromURL
   
@@ -19,6 +20,8 @@ public enum ScreenshotError: LocalizedError, Sendable {
       return "Can't create url for window capture"
     case .cantCreateNSImageFromURL:
       return "Can't create image from file"
+    case .processLaunchFailed(let errorMessage):
+      return "Error running capture tool: \" \(errorMessage) \""
     }
   }
 }


### PR DESCRIPTION
The crash has been happening for a long time and reported here: https://console.firebase.google.com/project/zappy-os-x/crashlytics/app/ios:com.blackbeltlabs.Zappy/issues/a9c6f5806caae350b38646c92d2cdf60?time=30d&types=crash&sessionEventKey=c68395ea2b784bfb98a0def0ac8c04b2_2181345245231958394

This PR fixes it.

**The crash explanation:**

Process.launch() (deprecated) throws an ObjC exception (not a Swift error) when:

The executable at launchPath doesn't exist or isn't executable
The process can't be spawned for permission reasons
The key problem: Process.launch() is deprecated and throws ObjC exceptions that cannot be caught by Swift do/catch. The method throws(ScreenshotError) on runTask will never catch this — ObjC exceptions bypass Swift error handling entirely, causing an unhandled exception → abort().

Why it happens

The most likely scenario is that /usr/sbin/screencapture is unavailable or not executable in certain system configurations. This can happen:

On macOS versions where screencapture was moved or has different permissions
On systems with SIP modifications or restricted environments
When sandboxed (future App Store target)
Fix

The fix needs to happen in the Screenshots package itself. 

Two changes are needed:

Replace task.launch() with task.run() — The modern run() method throws a proper Swift error instead of an ObjC exception
Replace task.launchPath with task.executableURL — The modern API that pairs with run()
